### PR TITLE
Added logic to separate past events

### DIFF
--- a/app/Http/Controllers/Web/OPController.php
+++ b/app/Http/Controllers/Web/OPController.php
@@ -44,7 +44,7 @@ class OPController extends Controller
         $event = DB::table('events')
             ->where('slug', $slug)
             ->where('active', 1)
-            ->select('name', 'slug', 'type', 'price', 'content')
+            ->select('name', 'slug', 'type', 'price', 'content', 'expires_on')
             ->first();
 
         if (!$event) {

--- a/app/Http/Controllers/Web/PaypalController.php
+++ b/app/Http/Controllers/Web/PaypalController.php
@@ -69,7 +69,7 @@ class PaypalController extends Controller
             Session::put('error','Unable to order more than 1 kit');
             return redirect()->back();
         }
-        if ($event->expires_on < time()) {
+        if (strtotime($event->expires_on) < time()) {
             Session::put('error','Kit no longer on sale');
             return redirect()->back();
         }

--- a/app/Http/Controllers/Web/PaypalController.php
+++ b/app/Http/Controllers/Web/PaypalController.php
@@ -50,7 +50,7 @@ class PaypalController extends Controller
 
         $event = DB::table('events')
             ->where('slug', $kit_slug)
-            ->select('price', 'type')
+            ->select('price', 'type', 'expires_on')
             ->first();
 
         return $event;
@@ -67,6 +67,10 @@ class PaypalController extends Controller
         $event = $this->getEvent($request->kit_slug);
         if ($event->type != 'GNK' and $request->number_of_kits > 1) {
             Session::put('error','Unable to order more than 1 kit');
+            return redirect()->back();
+        }
+        if ($event->expires_on < time()) {
+            Session::put('error','Kit no longer on sale');
             return redirect()->back();
         }
 

--- a/resources/views/pages/op/stores/detail.blade.php
+++ b/resources/views/pages/op/stores/detail.blade.php
@@ -16,54 +16,55 @@
                 </div>
             </div>
         </div>
-        <div class="container">
-            <div class="row">
-                <div class="col-sm-12">
-                    <h4 class="headline"><span>Purchase a tournament kit</span></h4>
-                </div>
-            </div>
-
-            @if ($message = Session::get('success'))
-                <div>
-                    <p>Purchase successful! We'll be in touch to help you organise your event asap.</p>
-                </div>
-                <?php Session::forget('success');?>
-            @else
-                @if ($message = Session::get('error'))
-                    <div>
-                        <p>Whoops, something went wrong checking out via paypal. If this continues to go wrong, or if you think you've been debited and are seeing this error incorrectly please get in touch and we'll sort it out.</p>
-                        <p style="color:red">{{ Session::get('error') }}</p>
+        @if (time() <= strtotime($event->expires_on))
+            <div class="container">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <h4 class="headline"><span>Purchase a tournament kit</span></h4>
                     </div>
-                    <?php Session::forget('error');?>
+                </div>
+
+                @if ($message = Session::get('success'))
+                    <div>
+                        <p>Purchase successful! We'll be in touch to help you organise your event asap.</p>
+                    </div>
+                    <?php Session::forget('success');?>
+                @else
+                    @if ($message = Session::get('error'))
+                        <div>
+                            <p>Whoops, something went wrong checking out via paypal. If this continues to go wrong, or if you think you've been debited and are seeing this error incorrectly please get in touch and we'll sort it out.</p>
+                            <p style="color:red">{{ Session::get('error') }}</p>
+                        </div>
+                        <?php Session::forget('error');?>
+                    @endif
+
+                    <div class="row">
+                        <p class="col-sm-12">Price per Kit: ${{ $event->price }}</p>
+                    </div>
+                    <div class="row">
+                        {{ Form::open(array('url' => 'paypal', 'class' => 'form')) }}
+                            {{ csrf_field() }}
+                            {{ Form::hidden('kit_name', $event->name, array('required' => 'true')) }}
+                            {{ Form::hidden('kit_slug', $event->slug, array('required' => 'true')) }}
+                            <div class="form-field" style="display: inline-block; vertical-align: bottom; width: 15rem;">
+                                {{ Form::label('requested_price', 'Amount paid per kit*') }}
+                                {{ Form::number('requested_price', $event->price, array('min' => $event->price, 'class' => 'form-field__dollar-box')) }}
+                            </div>
+                            <div class="form-field" style="display: inline-block; vertical-align: bottom; width: 15rem;">
+                                {{ Form::label('number_of_kits', 'Quantity *') }}
+                                @if ($event->type == 'GNK')
+                                    {{ Form::number('number_of_kits', 1, array('required' => 'true')) }}
+                                @else
+                                    {{ Form::number('number_of_kits', 1, array('disabled' => 'true')) }}
+                                @endif
+                            </div>
+                            <div class="form-field" style="display: inline-block; vertical-align: bottom; width: 8rem;">
+                                <input type="submit" value="Purchase">
+                            </div>
+                        {{ Form::close() }}
+                    </div>
                 @endif
-
-                <div class="row">
-                    <p class="col-sm-12">Price per Kit: ${{ $event->price }}</p>
-                </div>
-                <div class="row">
-                    {{ Form::open(array('url' => 'paypal', 'class' => 'form')) }}
-                        {{ csrf_field() }}
-                        {{ Form::hidden('kit_name', $event->name, array('required' => 'true')) }}
-                        {{ Form::hidden('kit_slug', $event->slug, array('required' => 'true')) }}
-                        <div class="form-field" style="display: inline-block; vertical-align: bottom; width: 15rem;">
-                            {{ Form::label('requested_price', 'Amount paid per kit*') }}
-                            {{ Form::number('requested_price', $event->price, array('min' => $event->price, 'class' => 'form-field__dollar-box')) }}
-                        </div>
-                        <div class="form-field" style="display: inline-block; vertical-align: bottom; width: 15rem;">
-                            {{ Form::label('number_of_kits', 'Quantity *') }}
-                            @if ($event->type == 'GNK')
-                                {{ Form::number('number_of_kits', 1, array('required' => 'true')) }}
-                            @else
-                                {{ Form::number('number_of_kits', 1, array('disabled' => 'true')) }}
-                            @endif
-                        </div>
-                        <div class="form-field" style="display: inline-block; vertical-align: bottom; width: 8rem;">
-                            <input type="submit" value="Purchase">
-                        </div>
-                    {{ Form::close() }}
-                </div>
-            @endif
-
-        </div>
+            </div>
+        @endif
     </div>
 @stop

--- a/resources/views/pages/op/stores/index.blade.php
+++ b/resources/views/pages/op/stores/index.blade.php
@@ -18,38 +18,47 @@
             </div>
         </div>
         <div class="container">
-            <div class="row masonry-grid">
+            <div class="row">
                 <div class="col-sm-12">
                     <h4 class="headline"><span>Available Kits</span></h4>
                     <br>
                 </div>
                 @foreach ($events as $event)
-                    <div class="col-sm-12 col-lg-6">
-                        <a class="event-card" href="/op/available-kits/{{ $event->slug }}">
-                            @if ($event->listing_image)
-                                <img src="{{ $event->listing_image }}" alt="{{ $event->name }}" class="event-card__image">
-                            @endif
-                            <p class="event-card__name">{{ $event->name }}</p>
-                            <p class="event-card__info">Base price: ${{ $event->price }}</p>
-                            <p class="event-card__info">On sale until: {{ $event->expires_on }}</p>
-                        </a>
-                    </div>
+                    @if (time() <= strtotime($event->expires_on))
+                        <div class="col-sm-12 col-lg-6">
+                            <a class="event-card" href="/op/available-kits/{{ $event->slug }}">
+                                @if ($event->listing_image)
+                                    <img src="{{ $event->listing_image }}" alt="{{ $event->name }}" class="event-card__image">
+                                @endif
+                                <p class="event-card__name">{{ $event->name }}</p>
+                                <p class="event-card__info">Base price: ${{ $event->price }}</p>
+                                <p class="event-card__info">On sale until: {{ $event->expires_on }}</p>
+                            </a>
+                        </div>
+                    @endif
+                @endforeach
+            </div>
+            <br>
+            <div class="row">
+                <div class="col-sm-12">
+                    <h4 class="headline"><span>Past Kits</span></h4>
+                    <br>
+                </div>
+                @foreach ($events as $event)
+                    @if (time() > strtotime($event->expires_on))
+                        <div class="col-sm-12 col-lg-6">
+                            <a class="event-card" href="/op/available-kits/{{ $event->slug }}">
+                                @if ($event->listing_image)
+                                    <img src="{{ $event->listing_image }}" alt="{{ $event->name }}" class="event-card__image">
+                                @endif
+                                <p class="event-card__name">{{ $event->name }}</p>
+                                <p class="event-card__info">Base price: ${{ $event->price }}</p>
+                                <p class="event-card__info">On sale until: {{ $event->expires_on }}</p>
+                            </a>
+                        </div>
+                    @endif
                 @endforeach
             </div>
         </div>
     </div>
-@stop
-
-@section('scripts')
-    <script>
-        var grids = document.querySelectorAll('.masonry-grid');
-        imagesLoaded( grids, function() {
-            for (let x = 0; x < grids.length; x++) {
-                let grid = grids[x];
-                var msnry = new Masonry( grid, {
-                    itemSelector: '.grid-item'
-                });
-            }
-        });
-    </script>
 @stop


### PR DESCRIPTION
Changed the "Available Kits" page so that any kits with an "Expires On" date in the past are shifted down into a "Past Kits" section and when opened do not show the purchasing section at the bottom, so people cannot attempt to purchase previous kits.

Would appreciate someone giving this a thorough once over to make sure I've not done anything dumb or missed anything - look forward to seeing all my bugs found! ;)