### PR TITLE
Cleaned up handling of available/past kits

### DIFF
--- a/resources/sass/app.css
+++ b/resources/sass/app.css
@@ -6961,6 +6961,11 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 1rem;
   margin-bottom: 0.5rem; }
 
+.event-card__subtle {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+  color: grey; }
+
 .form {
   margin-bottom: 3rem; }
 

--- a/resources/sass/components/_event-card.scss
+++ b/resources/sass/components/_event-card.scss
@@ -22,3 +22,8 @@
     font-size: 1rem;
     margin-bottom: 0.5rem;
 }
+
+.event-card__subtle {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+    color: grey; }

--- a/resources/views/pages/op/kit-policies.blade.php
+++ b/resources/views/pages/op/kit-policies.blade.php
@@ -53,7 +53,7 @@
             <h2>Running Events</h2>
 
             <h4 id="where-to-get">Where can I get the most recent event kits?</h4>
-            <p>Check out <a href="/op/available-kits">the Available Event Kits page</a>!</p>
+            <p>Check out <a href="/op/available-kits">the Event Kits page</a>!</p>
 
             <h4 id="scheduling">How do I avoid scheduling my event at the same time as another event? Is there a public listing of all events somewhere?</h4>
             <p>NISEI recommends using https://alwaysberunning.net for scheduling events. If you want to make absolutely sure, just stay in contact with your local meta - especially other event organizers. We are weighing adding event listing functionality to this website in the future.</p>

--- a/resources/views/pages/op/stores/index.blade.php
+++ b/resources/views/pages/op/stores/index.blade.php
@@ -40,7 +40,7 @@
                                     @endif
                                     <p class="event-card__name">{{ $event->name }}</p>
                                     <p class="event-card__info">Base price: ${{ $event->price }}</p>
-                                    <p class="event-card__info">On sale until: {{ $event->expires_on }}</p>
+                                    <p class="event-card__info">On sale through: {{ date_format(date_sub(date_create($event->expires_on),date_interval_create_from_date_string("1 day")),"F j, Y") }} (UTC)</p>
                                 </a>
                             </div>
                         @endif

--- a/resources/views/pages/op/stores/index.blade.php
+++ b/resources/views/pages/op/stores/index.blade.php
@@ -5,14 +5,14 @@
 @section('content')
 
     @include('partials.main-title', [
-        'heading' => 'Available Prize Kits'
+        'heading' => 'Event Kits'
     ])
 
     <div class="page-content">
         <div class="container">
             <div class="row">
                 <div class="col-sm-12">
-                    <p>Purchase available prize kits below! All prices are in US dollars and include shipping.</p>
+                    <p>Purchase event kits below! All prices are in US dollars and include shipping.</p>
                     <p>See <a href="/op/kit-policies">Event Kit Policies & FAQ</a> for details about how you can use these kits.</p>
                 </div>
             </div>

--- a/resources/views/pages/op/stores/index.blade.php
+++ b/resources/views/pages/op/stores/index.blade.php
@@ -26,48 +26,16 @@
                 });
             @endphp
             @if ($available->count() > 0)
-                <div class="row">
-                    <div class="col-sm-12">
-                        <h4 class="headline"><span>Available Kits</span></h4>
-                        <br>
-                    </div>
-                    @foreach ($available as $event)
-                        @if (time() <= strtotime($event->expires_on))
-                            <div class="col-sm-12 col-lg-6">
-                                <a class="event-card" href="/op/available-kits/{{ $event->slug }}">
-                                    @if ($event->listing_image)
-                                        <img src="{{ $event->listing_image }}" alt="{{ $event->name }}" class="event-card__image">
-                                    @endif
-                                    <p class="event-card__name">{{ $event->name }}</p>
-                                    <p class="event-card__info">Base price: ${{ $event->price }}</p>
-                                    <p class="event-card__info">On sale through: {{ date_format(date_sub(date_create($event->expires_on),date_interval_create_from_date_string("1 day")),"F j, Y") }} (UTC)</p>
-                                </a>
-                            </div>
-                        @endif
-                    @endforeach
-                </div>
-                <br>
+                @include('pages.op.stores.partials.index-events', [
+                    'heading' => 'Available Kits',
+                    'events' => $available
+                ])
             @endif
-            <div class="row">
-                <div class="col-sm-12">
-                    <h4 class="headline"><span>Past Kits</span></h4>
-                    <br>
-                </div>
-                @foreach ($past as $event)
-                    @if (time() > strtotime($event->expires_on))
-                        <div class="col-sm-12 col-lg-6">
-                            <a class="event-card" href="/op/available-kits/{{ $event->slug }}">
-                                @if ($event->listing_image)
-                                    <img src="{{ $event->listing_image }}" alt="{{ $event->name }}" class="event-card__image">
-                                @endif
-                                <p class="event-card__name">{{ $event->name }}</p>
-                                <p class="event-card__info">Base price: ${{ $event->price }}</p>
-                                <p class="event-card__subtle">Ended: {{ $event->expires_on }}</p>
-                            </a>
-                        </div>
-                    @endif
-                @endforeach
-            </div>
+            <br>
+            @include('pages.op.stores.partials.index-events', [
+                'heading' => 'Past Kits',
+                'events' => $past
+            ])
         </div>
     </div>
 @stop

--- a/resources/views/pages/op/stores/index.blade.php
+++ b/resources/views/pages/op/stores/index.blade.php
@@ -18,33 +18,42 @@
             </div>
         </div>
         <div class="container">
-            <div class="row">
-                <div class="col-sm-12">
-                    <h4 class="headline"><span>Available Kits</span></h4>
-                    <br>
+            @php
+                $available = [];
+                $past = [];
+                list($available, $past) = $events->partition(function ($event) {
+                    return time() < strtotime($event->expires_on);
+                });
+            @endphp
+            @if ($available->count() > 0)
+                <div class="row">
+                    <div class="col-sm-12">
+                        <h4 class="headline"><span>Available Kits</span></h4>
+                        <br>
+                    </div>
+                    @foreach ($available as $event)
+                        @if (time() <= strtotime($event->expires_on))
+                            <div class="col-sm-12 col-lg-6">
+                                <a class="event-card" href="/op/available-kits/{{ $event->slug }}">
+                                    @if ($event->listing_image)
+                                        <img src="{{ $event->listing_image }}" alt="{{ $event->name }}" class="event-card__image">
+                                    @endif
+                                    <p class="event-card__name">{{ $event->name }}</p>
+                                    <p class="event-card__info">Base price: ${{ $event->price }}</p>
+                                    <p class="event-card__info">On sale until: {{ $event->expires_on }}</p>
+                                </a>
+                            </div>
+                        @endif
+                    @endforeach
                 </div>
-                @foreach ($events as $event)
-                    @if (time() <= strtotime($event->expires_on))
-                        <div class="col-sm-12 col-lg-6">
-                            <a class="event-card" href="/op/available-kits/{{ $event->slug }}">
-                                @if ($event->listing_image)
-                                    <img src="{{ $event->listing_image }}" alt="{{ $event->name }}" class="event-card__image">
-                                @endif
-                                <p class="event-card__name">{{ $event->name }}</p>
-                                <p class="event-card__info">Base price: ${{ $event->price }}</p>
-                                <p class="event-card__info">On sale until: {{ $event->expires_on }}</p>
-                            </a>
-                        </div>
-                    @endif
-                @endforeach
-            </div>
-            <br>
+                <br>
+            @endif
             <div class="row">
                 <div class="col-sm-12">
                     <h4 class="headline"><span>Past Kits</span></h4>
                     <br>
                 </div>
-                @foreach ($events as $event)
+                @foreach ($past as $event)
                     @if (time() > strtotime($event->expires_on))
                         <div class="col-sm-12 col-lg-6">
                             <a class="event-card" href="/op/available-kits/{{ $event->slug }}">
@@ -53,7 +62,7 @@
                                 @endif
                                 <p class="event-card__name">{{ $event->name }}</p>
                                 <p class="event-card__info">Base price: ${{ $event->price }}</p>
-                                <p class="event-card__info">On sale until: {{ $event->expires_on }}</p>
+                                <p class="event-card__subtle">Ended: {{ $event->expires_on }}</p>
                             </a>
                         </div>
                     @endif

--- a/resources/views/pages/op/stores/partials/index-events.blade.php
+++ b/resources/views/pages/op/stores/partials/index-events.blade.php
@@ -1,0 +1,22 @@
+<div class="row">
+    <div class="col-sm-12">
+        <h4 class="headline"><span>{{ $heading }}</span></h4>
+        <br>
+    </div>
+    @foreach ($events as $event)
+        <div class="col-sm-12 col-lg-6">
+            <a class="event-card" href="/op/available-kits/{{ $event->slug }}">
+                @if ($event->listing_image)
+                    <img src="{{ $event->listing_image }}" alt="{{ $event->name }}" class="event-card__image">
+                @endif
+                <p class="event-card__name">{{ $event->name }}</p>
+                <p class="event-card__info">Base price: ${{ $event->price }}</p>
+                @if (time() <= strtotime($event->expires_on))
+                    <p class="event-card__info">On sale through: {{ date_format(date_sub(date_create($event->expires_on),date_interval_create_from_date_string("1 day")),"F j, Y") }} (UTC)</p>
+                @else
+                    <p class="event-card__subtle">Ended: {{ $event->expires_on }}</p>
+                @endif
+            </a>
+        </div>
+    @endforeach
+</div>

--- a/resources/views/pages/op/stores/partials/index-events.blade.php
+++ b/resources/views/pages/op/stores/partials/index-events.blade.php
@@ -12,7 +12,7 @@
                 <p class="event-card__name">{{ $event->name }}</p>
                 <p class="event-card__info">Base price: ${{ $event->price }}</p>
                 @if (time() <= strtotime($event->expires_on))
-                    <p class="event-card__info">On sale through: {{ date_format(date_sub(date_create($event->expires_on),date_interval_create_from_date_string("1 day")),"F j, Y") }} (UTC)</p>
+                    <p class="event-card__info">On sale through: {{ date_format(date_sub(date_create($event->expires_on),date_interval_create_from_date_string("1 day")),"F j, Y") }} (23:59 UTC)</p>
                 @else
                     <p class="event-card__subtle">Ended: {{ $event->expires_on }}</p>
                 @endif

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -30,7 +30,7 @@
                         Organised Play
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                        <a class="dropdown-item" href="/op/available-kits">Available Event Kits</a>
+                        <a class="dropdown-item" href="/op/available-kits">Event Kits</a>
                         <a class="dropdown-item" href="/op/supported-formats">Supported Formats</a>
                         <a class="dropdown-item" href="/op/resources">Resources</a>
                         <a class="dropdown-item" href="/op/kit-policies">Event Kit Policies & FAQ</a>


### PR DESCRIPTION
Changed behaviour of Available Kits page so that: 

- When there are no kits on sale, the Available Kits section is hidden entirely.
- Different info text is displayed for Past Kits ("Ended:" instead of "On sale until:")
- Info text on Past Kits is shown in a grey colour (tried red, but this seemed a bit much)

Example from my local instance with 2 expired kits and no currently available ones:

![image](https://user-images.githubusercontent.com/10621139/50779458-4f85ab80-1298-11e9-8f2d-59871e1af639.png)

Thoughts welcome! 😄 