### PR TITLE
Possible fix for RSS header image

### DIFF
--- a/app/Blog.php
+++ b/app/Blog.php
@@ -89,7 +89,7 @@ class Blog extends Model implements Feedable
 
     public function toFeedItem()
     {
-        $headerImageTag = '<img src="' . url('listing_images/' . $this->attributes['listing_image']) . '"/>';
+        $headerImageTag = '<img src="' . url($this->attributes['listing_image']) . '"/>';
         $summary = self::substr_close_tags($this->content, 200);
         $closing = '<a href="'. url('/article/' . $this->slug) . '">Read full article at NISEI.net</a>';
 

--- a/app/Blog.php
+++ b/app/Blog.php
@@ -89,7 +89,7 @@ class Blog extends Model implements Feedable
 
     public function toFeedItem()
     {
-        $headerImageTag = '<img src="' . url($this->attributes['listing_image']) . '"/>';
+        $headerImageTag = is_null($this->attributes['listing_image']) ? '' : '<img src="' . url($this->attributes['listing_image']) . '"/>' . '<br/>';
         $summary = self::substr_close_tags($this->content, 200);
         $closing = '<a href="'. url('/article/' . $this->slug) . '">Read full article at NISEI.net</a>';
 
@@ -97,7 +97,7 @@ class Blog extends Model implements Feedable
             ->id($this->id)
             ->title($this->title)
             ->updated(new Carbon($this->published_at))
-            ->summary($headerImageTag . '<br/>' . $summary . '<br><br>' . $closing)
+            ->summary($headerImageTag . $summary . '<br><br>' . $closing)
             ->link('/article/' . $this->slug)
             ->author($this->author->name);
     }


### PR DESCRIPTION
For some reason it doesn't appear that the listing image urls work the same between my local and the production.  Is anyone able to test in their dev environment and see if the header images display for blog posts.  If so, could you also verify the urls generated in the RSS feed with this fix?