### PR TITLE
Handle absence of a listing image gracefully

### DIFF
--- a/resources/views/pages/blog/detail.blade.php
+++ b/resources/views/pages/blog/detail.blade.php
@@ -1,7 +1,9 @@
 @extends('layouts.default')
 
 @section('page-title', 'NISEI - ' . $article->title)
-@section('opengraph-image', url($article->listing_image))
+@if ($article->listing_image)
+  @section('opengraph-image', url($article->listing_image))
+@endif
 
 @section('content')
 


### PR DESCRIPTION
Today, in "things Jen should have fixed when she first encountered them, instead of making a mental note to fix them later," we have the site's inability to display articles without listing images.