### PR TITLE
Updated blog index sort order

### DIFF
--- a/app/Http/Controllers/Web/BlogController.php
+++ b/app/Http/Controllers/Web/BlogController.php
@@ -28,6 +28,7 @@ class BlogController extends Controller
             ->join('users', 'blogs.author_id', '=', 'users.id')
             ->select('users.name as author_name', 'blogs.title', 'blogs.published_at', 'blogs.slug', 'blogs.listing_image')
             ->orderBy('published_at', 'desc')
+            ->orderBy('blogs.created_at', 'desc')
             ->get();
 
         return view('pages.blog.index', [


### PR DESCRIPTION
Realised today that because the articles are ordered by `published_at` only and this is a datestamp only, two articles published on the same day may not be published in the right order, so this fixes that.