### PR TITLE
Adding "Around the World" as a meta-finder subpage for OP

### DIFF
--- a/resources/views/pages/op/around-the-world.blade.php
+++ b/resources/views/pages/op/around-the-world.blade.php
@@ -1,0 +1,340 @@
+@extends('layouts.default')
+
+@section('page-title', 'Around The World')
+
+@section('content')
+
+    @include('partials.main-title', [
+        'heading' => 'Around The World'
+    ])
+
+    <div class="page-content">
+        <div class="container">
+            <p>We strongly believe that the biggest superpower our community has is each and every person playing the game. We want to help you find such people in your area. Take a look below and reach out to get involved!</p>
+            <p>The information below will be updated periodically. If you think it needs correcting or expanding, please let us know at <a href="mailto:op@nisei.net">op@nisei.net</a> - thank you!</p>
+            <h2>Communities Around The World</h2>
+            <h4>Australia & Oceania</h4>
+            <ul>
+                <li><a href="#au">Australia</a>.</li>
+            </ul>
+            <h4>Europe</h4>
+            <ul>
+                <li><a href="#cs">Czech Republic / Česká republika</a>.</li>
+                <li><a href="#de">Germany / Deutschland</a>.</li>
+                <li><a href="#fi">Finland / Suomi</a>.</li>
+                <li><a href="#hu">Hungary / Magyarország</a>.</li>
+                <li><a href="#it">Italy / Italia</a>.</li>
+                <li><a href="#pl">Poland / Polska</a>.</li>
+                <li><a href="#se">Sweden / Sverige</a>.</li>
+                <li><a href="#uk">United Kingdom</a>.</li>
+            </ul>
+            <h4>North America</h4>
+            <ul>
+                <li><a href="#ca">Canada</a>.</li>
+                <li><a href="#us">United States of America</a>.</li>
+            </ul>
+            <h4>South America</h4>
+            <ul>
+                    <li><a href="#br">Brazil / Brasil</a>.</li>
+            </ul>
+
+            <h2>Australia & Oceania</h2>
+                <h4 id="au">Australia</h4>
+                    <p><strong>Perth</strong></p>
+                        <p>We are a small group in the most isolated city in Australia. We are very self-contained and don't wind up playing with other groups very often. We are a community of about 18-20 players and our big events (Game Night Kit meetups & local championships) typically are 12-15 players.</p>
+                        <ul>
+                            <li><a href="https://www.facebook.com/groups/503195766407981/">Facebook - chat, events & news for Perth Netrunner</a>.</li>
+                            <li>Contact Brian - brian [at] taliskerhouse.com (in English).</li>
+                            <li>Find us at <a href="https://www.goodgames.com.au/au/stores/wa/cannington.html">Good Games Cannington</a>.</li>
+                        </ul>
+
+            <h2>Europe</h2>
+                <h4 id="cs">Czech Republic / Česká republika</h4>
+                    <p><strong>Brno</strong></p>
+                        <p>We are a bunch of people (usually around 4) meeting regularly in a nice gaming pub called Black Oil where they serve excellent beer and food. Together with people from Breclav community we regularly attend tournaments in Brno (which we organise), Prague or given our good location also in neighbouring countries (Hungary, Austria, Poland, Germany). We mainly communicate using Messenger and Slack.</p>
+                        <ul>
+                            <li><a href="https://www.facebook.com/groups/451646301640976/">The Facebook group called "Android: Netrunner Hodonín a přilehlý vesmír"</a>, in case you want to contact us just write something on our wall and we will respond almost immediately. The group is shared with people from Breclav and Brno community.</li>
+                            <li><a href="https://join.slack.com/t/netrunnercz/shared_invite/enQtMjMxMTk3NTIyODU1LTAzMGYzYWEzMjZmODNmY2Q5MDg0YWNlYzI3ZDI3NDU0MjQwNTVkMDFhYjVjNTUzZWJjZWRjMWI1MWE5Zjk2ZWY">The Slack channel</a> used mainly by players from Brno community.</li>
+                            <li>Contact Longi - miroslav.seckar [at] seznam.cz (in English, Czech) or Dante - jryska42 [at] gmail.com (in English, Czech).</li>
+                            <li><a href="https://goo.gl/maps/ZNBVPeNZtnEMax9C9">Black Oil - Gaming & Social Hub</a>: Kotlářská 989/51a, 602 00 Brno-střed-Veveří - mostly Thursday evenings (from 17:00 to 21:00).</li>
+                        </ul>
+                <h4 id="de">Germany / Deutschland</h4>
+                    <p><strong>Berlin</strong></p>
+                        <p>We are an active group, with a regular Thursday meetup of around 5 people. Have some own events from casual to competitive. All our events are listed on https://alwaysberunning.net/ // Wir seid eine aktive Community mit einem regelmäßigen Treffen Do mit ~ 5 Personen. Wir machen einige eigene Events von casual bis kompetitiv. Du findest alle unserer Termine auf https://alwaysberunning.net/</p>
+                        <ul>
+                            <li><a href="https://alwaysberunning.net/tournaments/190/berlin-rudis">Our regular Thursday meetup</a> - you'll find us or more contacts on the ABR page, to get an invite to our Discord server.</li>
+                            <li>Contact 5N00P1 - 5N00P1.ANR [at] gmail.com (in German, English).</li>
+                            <li><a href="https://goo.gl/maps/sMPsMrDaZEScP4En7">RuDi - Das Stralauer Kultur- und Nachbarschaftszentrum</a>, where we meet on Thursdays.</li>
+                        </ul>
+                    <p><strong>Koblenz</strong></p>
+                        <p>We are three players from Koblenz and two from Bad Kreuznach. We prefer Snapshot, Draft and Standard formats. // Wir sind drei Spieler aus Koblenz und zwei aus Bad Kreuznach. Meist gespielte Formate bei uns sind Standard, Draft und Snapshot.</p>
+                        <ul>
+                            <li>Contact Frizzler - weinschwaermer [at] web.de (in German).</li>
+                        </ul>
+                    <p><strong>NRW - Aachen</strong></p>
+                    <p>Play with us at the local store LVL9000. We don't have a lot of people in Aachen actively playing but we are good (current World Champion and runner-up!) and we also welcome everyone who is interested in getting to know the game. Just come over on Tuesday at 18:00. // Jeder ist im LVL9000 in Aachen willkommen. Wir sind zwar im Moment noch keine große Gruppe von Spielern aber wir sind sehr gut (aktueller Weltmeister und Vizeweltmeister!). Kommt dienstags ab 18:00 Uhr vorbei!</p>
+                    <ul>
+                        <li><a href="https://discord.gg/pnRg8W">Aachener City Grid</a> - join and connect in a browser tab or via the Discord app. // Schau vorbei und verbinde dich über deinen Browser oder die Discord app.</li>
+                        <li>Contact Felix - felix.lantin [at] gmail.com (in English, German).</li>
+                        <li><a href="https://level-9000.com/">LVL9000 Game Store</a>.</li>
+                    </ul>
+                    <p><strong>Southern Bavaria - Rosenheim City Grid - Landkreis including München and Traunstein</strong></p>
+                    <p>RCG is a group of casual/semi-competetive players, who just enjoy playing the game. We're doing alternative Format-Draft-BBQ-Runner Events regularly as well as Standard GNK Tournaments (though interest in those has waned) // RCG ist eine Gruppe aus Casual/Semi-kompetitiven Spielern, die einfach das Spiel gerne spielen. Wir veranstalten regelmässig alternative Format-Draft-BBQ-Runner Events aber auch Standard Turniere mit GNK-Kits(wobei das Interesse daran in letzter Zeit etwas abnahm)</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/304511856590911/">Our Local Facebook group</a>, nothing much happening there anymore but you can get in contact with us there :-D // Unsere örtliche Facebook Gruppe, nicht mehr viel los hier, aber man kann mit uns in Kontakt treten :-D.</li>
+                        <li><a href="https://rosenheim-city-grid.jimdosite.com/">Rosenheim City Grid website</a>.</li>
+                        <li>On <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>, contact Kai (@Late) (in English, German, Italian, Latin ;-) or Dominik (@Shorty) (in English, German).</li>
+                        <li><a href="http://bb-spiele.de/">BB Spiele Rosenheim</a> - Ebersbergerstr. 19-21, 83022 Rosenheim - Di-Fr: 15:00 - 20:00 Uhr, Sa.: 11:00 - 18:00 Uhr - not there a lot lately but they might have helpful information about our Group or how to contact us etc. // Wir sind nicht mehr regelmässig dort, aber die Angestellten können wahrscheinlich weiterhelfen wie Ihr mit uns in Kontakt treten könnt etc.</li>
+                    </ul>                        
+                <h4 id="fi">Finland / Suomi</h4>
+                    <p><strong>Helsinki</strong></p>
+                    <p>The Helsinki group is small, but active. We have usually around 4 players in weekly meetups and 8 players in smaller tournaments. Group trips to Tallinn tournaments are also done on regular basis. We welcome all the new players and hope you will have great time with this great game!</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/911303492267174/">Our Facebook group</a> - weekly meetups are decided here.</li>
+                        <li><a href="https://www.facebook.com/groups/anrsuomi/">If you are located elsewhere in Finland, you might find a playgroup from here</a>; also tournaments and group orders for new cards are posted here so everyone from Finland can attend.</li>
+                        <li>Contact AxWill - aleksi.pajunen [at] gmail.com (in Finnish, English, Google Translate).</li>
+                        <li>We usually play at Kaisla, but the weekly meetups are decided on the Facebook group based on people's personal schedules; you can also email AxWill, he is more than happy to keep you in the loop, teach the game and give tips where and what to buy.</li>
+                    </ul>
+                <h4 id="hu">France</h4>
+                <p><strong>Lyon</strong></p>
+                    <p>The 2nd biggest group in France! (We're four)</p>
+                    <ul>We have a section in the recently made<a href="https://district99.forumactif.com/f11-lyon-city-grid">French Netrunner forum</a>.</li>
+                    <li>Contact Passelune - jorniste [at] laposte.net.</li>
+                    <li>Find us at <a href="http://www.trollune.fr/">Trollune</a> on Mondays.</li>
+                </ul>
+                <h4 id="hu">Hungary / Magyarország</h4>
+                <p><strong>Budapest</strong></p>
+                    <p>In Budapest we have a roughly 8 person group that is glad for anyone new or traveling to join us :) We have a weekly meetup, usually a tournament in most months and some very talented and helpful players. // Budapesten van egy kb. 8 fős metánk aki szívesen lát új vagy csak látogató játékosokat :) Van egy heti játszós esténk, általában havonta egy verseny, valamint tehetséges és segítőkész játékosaink.</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/505519816175373/">A Facebook group</a> where you can find most of the Hungarian players // Egy Facebook csoport amiben a legtöbb magyar játékos benne van.</li>
+                        <li><a href="https://stimhackslackinvite.herokuapp.com/">The Stimhack Slack invite</a>, as you can find us in the #hu channel // A Stimhack Slack meghívója, mert ott is van saját csatornánk #hu névvel.</li>
+                        <li>Contact Dinya Péter "percomis" - percomis [at] gmail.com, find me on Facebook, Slack (in Hungarian, English, and German) // megtalálhattok Facebookon, Slacken. Írhattok magyarul, angolul és németül.</li>
+                        <li>Contact Madarász István "Necro", also available on Facebook and Slack. Try with Hungarian or English // Madarász István "Necro, szintúgy megtalálható Facebook-on és Slack-en. Magyarul vagy angolul próbálkozzatok.</li>
+                        <li>We usually play on Wednesdays (we're currently trying out different days though, so might change) at a place called <a href="https://goo.gl/maps/EnsgzNuhEWwpy7D19">Metagame</a> (1132 Kádár u. 10). It's in a cellar with stairs leading down, so probably not wheelchair friendly, but we will try to solve any issue the venue might present for someone. // Általában szerdánként játszunk (bár most épp másik napokkal próbálkozunk, úgyhogyváltozhat) egy <a href="https://goo.gl/maps/EnsgzNuhEWwpy7D19">Metagame</a> nevű helyen (1132 Kádár u. 10). Egy pincében van ahova lépcsők vezetnek, úgyhogy vélhetően nem kerekesszék-barát, de megpróbálunk minden gondot megoldani, amit a helyszín okozhat bárkinek.</li>
+                    </ul>
+                <h4 id="it">Italy / Italia</h4>
+                <p><strong>Piedmont - Turin / Piemonte - Torino</strong></p>
+                    <p>Here in Turin we usually play homemade decklists that span from the jankiest combos to the most cancerous decks. The only thing that matters is to have fun! // A Torino di solito giochiamo mazzi artigianali che vanno dalle combo più jank ai mazzi più cancerogeni al mondo. L'unica cosa importante è divertirsi!</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/netrunner.italia/">Android Netrunner LCG Italia"</a> Facebook group gathers together all Italian players. Go there and ask about players in Turin.</li>
+                        <li>Contact Enrico - enrico.reb89 [at] gmail.com (in Italiano, English).</li>
+                        <li><a href="https://alwaysberunning.net/tournaments/1625/monday-night-netrunner-at-jolly-joker">Our weekly meetup.</li>
+                        <li><a href="http://www.jollyjokercafe.it/">Jolly Joker Game Cafè</a> - Monday night.</li>
+                    </ul>
+                <h4 id="pl">Poland / Polska</h4>
+                <p><strong>Poznań</strong></p>
+                    <p>We're a friendly bunch of folks who fell in love with a certain cyberpunk card game with servers and ice. We'll show you why you too are bound to fall in love with it. // Jesteśmy grupą przyjaznych ludków, którzy zakochali się w pewnej cyberpunkowej grze karcianej z serwerami i lodami. Pokażemy Ci, dlaczego Tobie także jest przeznaczone zakochać się w tej grze.</p>
+                    <ul>
+                        <li><a href="http://netrunner-poznan.github.io/">A landing page for the group</a>, with contact info and a link to <a href="https://www.facebook.com/groups/android.netrunner.poznan/">the Facebook group</a>, where most of the action happens / Strona główna naszej grupy, z danymi kontaktowymi i linkiem do grupy facebookowej, gdzie odbywa się większość komunikacji.</li>
+                        <li>Contact Sebastian 'rattkin' Zarzycki - sebastian.zarzycki [at] gmail.com (in English, Polish, happy to use Google Translator for other cases :) or Jakub '@Bookkeeper' Eichler - kubaeichler [at] gmail.com (in English, Polish).</li>
+                        <li><a href="https://www.facebook.com/alternativaclub/">Alternativa Club</a> (ul. Św. Marcina 80/82) - (roughly) every Thursday, 18-22. We change the schedule and place during summer, contact via Facebook to learn more. We're also happy to arrange a meeting pretty much anywhere in the city. // Alternativa Club - zwykle w każdy czwartek, 18-22. Latem zwykle gramy gdzie indziej, najlepiej zapytać przez Facebook. Chętnie też zorganizujemy granie w dowolnym innym miejscu w mieście.</li>
+                    </ul>
+                <h4 id="se">Sweden / Sverige</h4>
+                    <p><strong>Linköping</strong></p>
+                    <p>För tillfället är vi väldigt få aktiva spelare i Linköping, så vi är väldigt intresserade av att få in nya spelare. // At the moment we have very few active players in Linköping, so we are very interested in attracting new players.</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/243050025859902/">Our Facebook group </a> is a good starting point to get in touch with us.</li>
+                        <li>Contact Harald Nautsch - hnautsch [at] gmail.com</a> (in Swedish, English, German).</li>
+                        <li>At the moment the weekly meetup is on hold, since we are so few people actively playing. Contact us via the Facebook group or by email.</li>
+                    </ul>
+                <h4 id="uk">United Kingdom</h4>
+                    <p><strong>Aldershot</strong></p>
+                        <p>We are a friendly group of 7 players with a mix of new and experienced players.</p>
+                        <ul>
+                            <li>The #readox channel on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>. It's a discussion point for a group that extends beyond Oxford to incorporate Reading and Aldershot, as well as surrounding areas.</li>
+                            <li>Contact Rotage - aldershotnisei [at] gmail.com (in English).</li>
+                            <li>We usually meet in the Games Shop in Aldershot every Wednesday but please contact us first to  make sure we will be there. Not Wheelchair friendly.</li>
+                        </ul>
+                    <p><strong>London</strong></p>
+                        <p>The game is alive and well in London. Our main meetup is every Tuesday evening in London Bridge, and we also have a monthly meetup in east London, near Stratford station. We have occasional Game Night Kit events at various locations around the city. We held a 29-person Regional tournament in July, and you'll usually find a few Londoners up for travelling to any event in the south of England.</p>
+                        <ul>
+                            <li><a href="https://www.facebook.com/groups/493537727405068/">Our Facebook group</a>, the London City Grid. Questions are usually answered fairly promptly.</li>
+                            <li>#thamesidedeckclub for London chat and porg emojis - on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                            <li>Contact Andi Thomas - andi.j.thomas [at] gmail.com (@twisty_b on Stimhack Slack) (in English) or Rufus Eyre-Varnier - reyrevarnier [at] gmail.com (@rusefus on Slack) (in English).</li>
+                            <li>downstairs at <a href="https://goo.gl/maps/3j6Bb1jaa2XeQNnG9">The Old Thameside Inn</a>, London SE1 9DG - every Tuesday evening from about 6pm - unfortunately not wheelchair accessible - if booked, we'll be in <a href="https://goo.gl/maps/WsieqC8ZjXPj1DELA">The Sheaf</a> just down the road.</li>
+                        </ul>
+                    <p><strong>Manchester</strong></p>
+                        <p>The Greater Manchester Netrunner Server has Pubrunner events every Monday night, at The Wharf, Castlefield, and (roughly) monthly Game Night Kit events, sometimes at Fanboy 3. Many of us also travel around the country together to play.</p>
+                        <ul>
+                            <li><a href="https://www.facebook.com/groups/manchesterserver/">Facebook Group for Greater Manchester Server</a>, covering events and social posts.</li>
+                            <li><a href="https://app.slack.com/client/T0AV68M8C/C0JUWR67K">#uk</a> on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                            <li>Contact Mark - grenergi [at] hotmail.com (@mcg on Stimhack Slack) (in English) or Russell (@tolaasin on Stimhack Slack) (in English).</li>
+                            <li><a href="https://www.brunningandprice.co.uk/thewharf/">The Wharf</a>, Castlefield - Monday evenings from 18:00.</li>
+                        </ul>
+                    <p><strong>Oxford</strong></p>
+                        <p>In Oxford we meet up Monday nights at "Thirsty Meeples", a gaming store. We generally play casually but hold the occasionaly "Game Night Kit" tournament. There's is a fee paid to the store every time we play but it's a nice cafe environment. We tend to have a reputation for a more... creative approach to the game than a competitive one but we do OK. We also form part of "Readoxershot" which is a group that includes us, Reading, and Aldershot - those keen on more tournaments can usually get lifts to there.</p>
+                        <ul>
+                            <li><a href="https://www.facebook.com/groups/700404386667402/">Our Facebook group</a> mainly used to check who is coming to our Monday meet ups. We will try to keep it updated on other things happening elsewhere.</li>
+                            <li>The #readox channel on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>. It's a discussion point for a group that extends beyond Oxford to incorporate Reading and Aldershot, as well as surrounding areas.</li>
+                            <li>Contact Guy - guypatching [at] googlemail.com (in English).</li>
+                            <li><a href="https://goo.gl/maps/fhMKcevYVxERMQE4A">Thirsty Meeples</a>, Gloucester Green, Oxford - Monday evenings around 18.00.</li>
+                        </ul>
+                    <p><strong>Scotland - Edinburgh</strong></p>
+                        <p>We're very nice and like to play weekly, in a quiet pub. We also have monthly events, ranging from Game Nigh Kit tournament to Regional tournaments.</p>
+                        <ul>
+                            <li><a href="https://www.facebook.com/groups/edinburghcardgamers/">Our Facebook group</a>. Access is available on request and we're generally pretty quick in responding.</li>
+                            <li>Contact Seamus - theobagpiper [at] gmail.com (in English).</li> or Alice - alice.rees90 [at] gmail.com (in English).</li>
+                            <li><a href="https://www.facebook.com/CrosstownED/">Crosstown Eatery and Drinkery</a> - Thursday evenings.</li>
+                        </ul>
+                    <p><strong>Scotland - Stirling</strong></p>
+                        <p>Stirling Ghost Branch meet regularly for both casual and organised play. Most meetings take place at Common Ground Games in Stirling.</p>
+                        <ul>
+                            <li>You can find the latest local events and news as well as links to useful documents or contact us for more information <a href="https://www.facebook.com/stirlingghostbranch/">on our Facebook group</a>.</li>
+                            <li>Contact Callum - stirling.ghost.branch [at] gmail.com (in English).</li>
+                            <li><a href="http://www.commongroundgames.co.uk/">Common Ground Games</a> - Tuesday nights.</li>
+                    <p><strong>Sheffield</strong></p>
+                        <p>Sheffield has a small group of enthusiastic players! We meet every Thursday at The Museum pub for casual games and also host regular tournaments at Patriot Games.</p>
+                        <ul>
+                            <li><a href="https://alwaysberunning.net/tournaments/886/sheffield-pubrunner-weekly-casual-meet-up">Details of our weekly "Pubrunner" meeting</a>.</li>
+                            <li><a href="https://www.facebook.com/groups/695832080528276/">Sheffield Pubrunner Facebook group</a> for organising meet-ups.</li>
+                            <li>Contact Paul Gillibrand - pauly [at] me.com (in English).</li>
+                            <li><a href="https://www.greeneking-pubs.co.uk/pubs/south-yorkshire/museum/">The Museum pub</a> - Thursdays from 6pm.</li>
+                        </ul>
+                    <p><strong>South West (Somerset) - Taunton</strong></p>
+                        <p>We've had a small group running for a year or so in Taunton, where we try to place the focus on welcoming new players and making people feel comfortable so they can enjoy the game. We also have a slight addiction to prize support, so no-one ever leaves one of our events empty handed! We've hosted countless Game Night Kit events, a Store Championship, and a Regional since NISEI came into existence and we're looking forward to hosting even more in the future!</p>
+                        <ul>
+                            <li><a href="https://www.facebook.com/groups/1971717656488151/">The Taunton Netrunners Facebook group</a> is a great place to start if you want to connect with other players in the Somerset and SW UK areas. We also have a FB chat group which we'd be happy to invite you to if you want!.</li>
+                            <li>#taunton on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                            <li>Contact Ian Witt - ianwittuk [at] gmail.com (@3N1GM4 on Stimhack Slack) (in English).</li>
+                            <li>We have a regular meetup (<a href="https://www.facebook.com/events/287159272004136/">Facebook</a>) (<a href="https://alwaysberunning.net/tournaments/1173/taunton-casual-netrunner-wednesdays">ABR</a>)on Wednesday evening at The Geek Lab UK on Station Road.</li>
+                        </ul>
+            <h2>North America</h2>
+                <h4 id="ca">Canada</h4>
+                <p><strong>Alberta - Calgary</strong></p>
+                    <p>Calgary area Netrunners!</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/CalgaryLCG/">Our Facebook group</a>.</li>
+                        <li>See us on #yyc on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                    </ul>
+                <p><strong>Alberta - Edmonton</strong></p>
+                    <p>The Edmonton scene has been lively and fresh since the original release of ANR, meeting Wednesdays at Table Top Cafe since 2012, creating our own facebook profile in 2013. We average around 7-8 steady players with peaks in the 20's for some higher profile tournaments.</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/Netrunners/">The Edmonton Netrunner Facebook group</a>.</li>
+                        <li>Contact Laury Plant - lauryplant [at] gmail.com or Josh Bazin joshthegeer [at] gmail.com</li>
+                        <li><a href="https://g.page/table-top-cafe-edmonton?share">Table Top Cafe</a> 124th Street - Wednesdays at 7pm.</li>
+                    </ul>
+                <p><strong>Ottawa</strong></p>
+                    <p>A small but dedicated group of Netrunner players in the Ottawa/Gatineau region. Regular Game Night Kit events and other tournaments. Fairly casual, very newbie friendly.</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/netrunnergrid">The Ottawa-Gatineau Facebook group</a> - the best place to reach players, announcements of tournaments and regular meetups, etc.</li>
+                        <li>Contact Max Won - max_won93 [at] hotmail.com (in English, Korean) or Hany Hebisha - Hanyhebisha [at] yahoo.ca (in English).</li>
+                        <li>Mondays about 6pm at the <a href="https://goo.gl/maps/MMqZLZyJnBhr5UNWA">Foolish Chicken</a> - 79 Holland Avenue, Ottawa. We usually play upstairs so that is a mobility issue.</li>
+                    </ul>
+                <p><strong>Toronto</strong></p>
+                    <p>Welcome to Torsaug City Grid (TORonto + MissisSAUGa). We’re an active meta with two weekly meetups (Tuesdays at 401 Games and Wednesday at The Rhino Bar & Grill). We’re friendly as can be, and would be thrilled to meet people who either already play Netrunner or are just curious about the game.</p>
+                    <ul>
+                        <li><a href="https://discord.gg/fTbjyGR">Our Discord server</a>, where we talk about Netrunner and whether a hot dog is a sandwich.</li>
+                        <li><a href="https://facebook.com/groups/torsaug/">Our Facebook group page</a>, where we make larger announcements. We're not quite as active here, but we try to keep it up-to-date.</li>
+                        <li>Contact the general Torsaug email account - torsaug [at] gmail.com (in English) or Adam Marostica - adammarostica [at] gmail.com (in English, French).</li>
+                        <li>Tuesdays at <a href="https://goo.gl/maps/YkQNgRdop3zmbhRA7">401 Games</a> - 750 Yonge Street</li>
+                    </ul>
+                <p><strong>Vancouver</strong></p>
+                    <p>A group for people in the greater Vancouver area. We meet weekly for games at a pub, and usually have monthly tournaments.</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/vancouvernetrunner/">Our Facebook group</a>, where all our local events and meetups are organized.</li>
+                        <li>#vancouver on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                        <li>Contact Keith / thike - keith.gaudry [at] gmail.com (in English).</li>
+                        <li><a href="http://www.lionspub.ca/">Lion's Pub</a> - Tuesday Evenings for casual play.</li>
+                    </ul>
+                <h4 id="us">United States of America</h4>
+                <p><strong>Arizona - Phoenix</strong></p>
+                    <p>It's hot outside - come in and run nets with us!</p>
+                    <ul>
+                        <li><a href="http://bit.ly/PhxNetrunner">Discord server with a fancy vanity link</a>.</li>
+                        <li><a href="https://www.meetup.com/">Phoenix-Netrunner-Meetup/>Our Meetup page</a> will stay up to date with the latest tournaments and schedule information!.</li>
+                        <li>Contact Devin - netrunner [at] dirjel.com (in English).</li>
+                        <li><a href="https://maps.app.goo.gl/9Y3m5CFBGL2dN12k8">Phoenix Gaming Lounge</a> - We play every other Wednesday. Show up any time between 3 and midnight, stay as long as you like, extra decks available on site!.</li>
+                    </ul>
+                <p><strong>Colorado - Denver</strong></p>
+                    <p>We are a fun and friendly group who are still going strong!</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/458432717581000/">Our Facebook group</a>, where we post all upcoming tournaments and meetups.</li>
+                        <li>Join the #peakefficiency channel on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                        <li>Contact Alexis Spicer - alexiscspicer [at] gmail.com (in English) or Elliott Hedman - hedman [at] buildempathy.com (in English).</li>
+                        <li><a href="https://goo.gl/maps/kqZtUHeGu1N4co3C7">The Wizard's Chest</a> on Broadway - we typically meet there every Thursday at 6pm, please check the Facebook group to make sure the meet is happening. Free parking!</li>
+                    </ul>
+                <p><strong>Connecticut</strong></p>
+                    <p>A group dedicated to the Living Card Game Android: Netrunner, meeting the 1st and 3rd Thursday of the month in the New Haven, CT area and the 2nd and 4th Thursday of the month in central CT.</p>
+                    <ul>
+                        <li>Join <a href="https://fb.com/groups/nhnetrunner">our Facebook group</a> for Event information.</li>
+                        <li>Contact Mark McKnight - disperse.recording [at] gmail.com (in English)</li>
+                        <li>Thursdays at <a href="https://g.page/ElmCityGames?share">Elm City Games</a> - 71 Orange Street, New Haven, CT 06510.</li>
+                    </ul>
+                <p><strong>Indiana - South Bend</strong></p>
+                    <p>A small casual/competitive group inactive right now but often willing to meet up and play at local game store, Martin's etc. All levels of players welcome. We are willing to teach the game, loan you cards, and do anything to get our cards out! Join "South Bend Netrunner Coalition" on Facebook and post for help!</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/690332184349527/">Facebook Group - South Bend Netrunner Coalition</a>.</li>
+                        <li>Contact x3r0h0ur - x3r0h0ur [at] gmail.com (in English).</li>
+                        <li>Fantasy Games or Martin's Cafe throughout the area.</li>
+                    </ul>
+                <p><strong>Midwest - Cincinnati</strong></p>
+                    <p>It's down to just two of us, but we still play and attend regional events!</p>
+                    <ul>
+                        <li>#cincinnati on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                        <li>Contact Noah Bogart - nbtheduke [at] gmail.com (in English).</li>
+                        <li>We don't have a dedicated space anymore, as Arkham Games closed and the rest of the community dropped out. We schedule on Slack!</li>
+                    </ul>
+                <p><strong>Northeast - Boston</strong></p>
+                    <p>Regular meetings in Pandemonium Books and Games.</p>
+                    <ul>
+                        <li><a href="https://alwaysberunning.net/tournaments/2293/pandemonium-weekly-meetup-boston-ma">Weekly meetup details</a> for Pandemonium Books and Games in Boston.</li>
+                        <li>#pandemonium on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>, then ask in #general to be added to the channel.</li>
+                        <li>Contact Ben W - @solemnstorm on Stimhack Slack (in English).</li>
+                        <li>Pandemonium Books & Games - http://www.pandemoniumbooks.com - 6-10pm Thursdays.</li>
+                    </ul>
+                <p><strong>Rhode Island - Cranston</strong></p>
+                    <p>A very small group that is slowly growing.  We meet at Brutopia in Cranston, which is a brewpub. Mostly inexperienced players with some new players</p>
+                    <ul>
+                        <li>Join #boswash for the greater US Northeast and message @DanB on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                        <li>Contact Dan Bouchard - mail [at] danbouchard.com (in English).</li>
+                        <li><a href="https://g.page/revivalbrewing?share">Brutopia</a> in Cranston, RI on Thursday evenings.</li>
+                    </ul>
+                <p><strong>San Diego</strong></p>
+                    <p>We’d love for people to join us at At Ease Games to play Netrunner! We welcome everyone from kitchen table players to competitive players, so you’re bound to find someone your speed to play with!</p>
+                    <ul>
+                        <li>Join us on the <a href="https://www.facebook.com/groups/West-Coast-Netrunners-102472489909018/">West Coast Netrunners Facebook group</a>.</li>
+                        <li>Join us at #socal on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                        <li>Contact Patrick Burk - pburk89 [at] gmail.com/@bluehg on Stimslack (in English).</li>
+                        <li><a href="https://goo.gl/maps/P74ugoakL7TrUVUy8">At Ease Games Gaming & Tournament Center</a> - Thursdays around 6/7 until close!</li>
+                    </ul>
+                <p><strong>San Francisco Bay Area</strong></p>
+                    <p>We are large and diverse group dedicated to Netrunner in both casual and competitive settings. We have multiple casual meet ups every week, a few competitive Game Night Kits every month, and several higher level tournaments throughout the year. Some really successful players have come from our meta. But we are always adding new players and helping them enjoy the game; whether that is refining their skills for competition, encouraging unique deck building ideas, or just enjoying some cardboard.</p>
+                    <ul>
+                        <li><a href="http://sansanfrancisco.net">A website for all the local information</a>.</li>
+                        <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSeL5d2wCj7FQTTBTKZzSJPlTtSU1bLj47bpfkdfNkoKrfYsIg/viewform">A Google form</a> to join the Bay Area Slack. Fill out the form and we'll send you an invite.</li>
+                        <li>Contact @swan on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a> or kirkaduran2 [at] gmail.com.</li>
+                        <li>Every Thursday night: <a href="https://goo.gl/maps/sL8yVoQRprsLm2957">GameScape</a> - 333 Divisadero St, San Francisco, CA 94117.</li>
+                        <li>Every Wednesday night: <a href="https://goo.gl/maps/rbptnRp4rMNfDQJQ6">Victory Point</a> - 1797-A Shattuck Ave, Berkeley, CA 94709.</li>
+                    </ul>
+                <p><strong>Texas - Austin</strong></p>
+                    <p>Welcome to the Austin City Grid! We're a mix of old and new players who like to jam games and drink beverages, and we'd love to have you join us for a weekly meetup or a monthly Game Night Kit!</p>
+                    <ul>
+                        <li>#austin-city-grid on <a href="https://stimhackslackinvite.herokuapp.com/">Stimhack Slack - join and connect in a browser tab</a>.</li>
+                        <li><a href="https://alwaysberunning.net/tournaments/2277/austin-city-grid-weekly-meetup">Our weekly Pubrunner meetups</a>. The Game Night Kit info comes out periodically as they get organized, but they're monthly, 3rd Saturday of the month.</li>
+                        <li>Contact Brandon - brandon.gannicott [at] gmail.com (in English) or Cameron - errantmage [at] gmail.com (in English).</li>
+                        <li><a href="https://www.facebook.com/Emerald.Tavern.Games.and.Cafe/">Emerald Tavern</a> - 6:30pm on Thursdays.</li>
+                    </ul>
+                <p><strong>Washington - Olympia</strong></p>
+                    <p>Olympia's Netrunner scene prides itself on spicy deckbuilding and an inclusive community environment. We meet at Olympic Cards and Comics for casual games on Tuesday nights, and have been experimenting with GNKs as fundraisers to support important work being done in our community. Come join us, we're always happy to lend decks and teach new players.</p>
+                    <ul>
+                        <li><a href="https://discord.gg/v9fu6CM">Oly Netruns: Discord Server - join on Discord</a>.</li>
+                        <li><a href="https://www.facebook.com/Gabis-Olympic-Cards-Comics-100681268142/">Olympic Cards and Comics on Facebook</a> - host of our Tuesday night meetup.</li>
+                        <li>Contact Zoe (zgc) - zoegc [at] pm.me (in English) or Jen - mothra.levine [at] gmail.com (in English).</li>
+                        <li><a href="https://www.facebook.com/Gabis-Olympic-Cards-Comics-100681268142/">Olympic Cards and Comics</a> - Tuesday evenings.</li>
+                    </ul>
+            <h2>South America</h2>
+                <h4 id="br">Brazil / Brasil</h4>
+                    <p><strong>Belo Horizonte - Minas Gerais</strong></p>
+                        <p>Somos uma pequena, porém dedicada, comunidade de jogadores investidos em manter vivo o melhor card game de todos os tempos, em Belo Horizonte. Sempre de portas abertas a novatos e aos jogadores experientes. // We are a small, but dedicated, community of players keeping alive the best card game ever in Belo Horizonte. We welcome new and experienced players alike.</p>
+                        <ul>
+                            <li><a href="https://www.facebook.com/groups/bhnetrunner/">Grupo do Facebook da Netrunner BH</a>, o melhor lugar para informações atualizadas de eventos, encontros e o meta // Facebook group for Netrunner BH, the best place for all local info on events, meet ups and the meta.</li>
+                            <li><a href="https://chat.whatsapp.com/IoOQzlYl4Me45Jcva97M4A">Grupo do Whatsapp</a>, para conversas instantâneas // Whatsapp group, for instant messaging.</li>
+                            <li>Contact Igor "Bone" Toscano - toscano.igor [at] gmail.com (in English, Portuguese, Italian, Spanish).</li>
+                            <li><a href="https://www.facebook.com/TCGeek/">TCGeek</a> - todas as quartas às 18 horas // every Wednesday at 6 PM. Sem acessibilidade, mas é possível dar um jeito, basta entrar em contato com antecedência // Not wheelchair friendly, but we can arrange something, just contact beforehand.</li>
+                        </ul>
+            <p>We also invite you to check <a href="https://alwaysberunning.net/">Always Be Running</a>, the main event organization and tracking platform for our community, especially the "Recurring events / meetups" section you can find on the main page.</p>
+            <p>See you on the other side of a table. <strong>Always Be Running!</strong></p>
+        </div>
+    </div>
+
+@stop

--- a/resources/views/pages/op/around-the-world.blade.php
+++ b/resources/views/pages/op/around-the-world.blade.php
@@ -267,6 +267,14 @@
                         <li>Contact x3r0h0ur - x3r0h0ur [at] gmail.com (in English).</li>
                         <li>Fantasy Games or Martin's Cafe throughout the area.</li>
                     </ul>
+                    <p><strong>Michigan - Metro Detroit, Ann Arbor</strong></p>
+                    <p>This group was created to help cultivate an active community and connect players for regular and organized play throughout Metro Detroit area.</p>
+                    <ul>
+                        <li><a href="https://www.facebook.com/groups/metrodetroitnetrunner">Our publick Facebook group</a> - weekly updates, local events and meetups.</li>
+                        <li><a href="https://alwaysberunning.net/tournaments/2165/ann-arbor-weekly-tuesday-meetup">The Tuesday meet-up of the Ann Arbor group.</a></li>
+                        <li>Contact Tim - tvaduva [at] yahoo.com (English, and very rusty Romanian).</li>
+                        <li>Tuesday Meetup - 6 PM at <a href="https://goo.gl/maps/feoMtNN8R5MpN8nu8">Starbucks</a> on 1214 S University Ave, Ann Arbor, MI 48104</li>
+                    </ul>
                 <p><strong>Midwest - Cincinnati</strong></p>
                     <p>It's down to just two of us, but we still play and attend regional events!</p>
                     <ul>

--- a/resources/views/pages/op/around-the-world.blade.php
+++ b/resources/views/pages/op/around-the-world.blade.php
@@ -10,6 +10,7 @@
 
     <div class="page-content">
         <div class="container">
+            <p>Are you completely new to the game and want to meet more people to enjoy it with? Are you a seasoned player looking for groups around the world while travelling? Maybe you've just moved cities or countries and are wondering if there's a group in your new home area?</p>
             <p>We strongly believe that the biggest superpower our community has is each and every person playing the game. We want to help you find such people in your area. Take a look below and reach out to get involved!</p>
             <p>The information below will be updated periodically. If you think it needs correcting or expanding, please let us know at <a href="mailto:op@nisei.net">op@nisei.net</a> - thank you!</p>
             <h2>Communities Around The World</h2>

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -30,6 +30,7 @@
                         Organised Play
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarOPDropdown">
+                        <a class="dropdown-item" href="/op/around-the-world">Around The World</a>
                         <a class="dropdown-item" href="/op/available-kits">Event Kits</a>
                         <a class="dropdown-item" href="/op/supported-formats">Supported Formats</a>
                         <a class="dropdown-item" href="/op/resources">Resources</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,7 @@ Route::get('/about/code-of-conduct', function () { return view('pages/about/code
 Route::get('/about/faqs', function () { return view('pages/about/faqs'); });
 
 Route::get('/find-people', function() { return redirect('/op/around-the-world'); });
-Route::get('/find-people', function() { return view('pages/op/around-the-world'); });
+Route::get('/op/around-the-world', function() { return view('pages/op/around-the-world'); });
 
 Route::get('/op', function() { return redirect('/op/available-kits'); });
 Route::get('/op/supported-formats', function() { return view('pages/op/formats'); });

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ Route::get('/about/nisei', function () { return view('pages/about/nisei'); });
 Route::get('/about/code-of-conduct', function () { return view('pages/about/code-of-conduct'); });
 Route::get('/about/faqs', function () { return view('pages/about/faqs'); });
 
+Route::get('/find-people', function() { return redirect('/op/around-the-world'); });
 Route::get('/find-people', function() { return view('pages/op/around-the-world'); });
 
 Route::get('/op', function() { return redirect('/op/available-kits'); });

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,8 @@ Route::get('/about/nisei', function () { return view('pages/about/nisei'); });
 Route::get('/about/code-of-conduct', function () { return view('pages/about/code-of-conduct'); });
 Route::get('/about/faqs', function () { return view('pages/about/faqs'); });
 
+Route::get('/find-people', function() { return view('pages/op/around-the-world'); });
+
 Route::get('/op', function() { return redirect('/op/available-kits'); });
 Route::get('/op/supported-formats', function() { return view('pages/op/formats'); });
 Route::get('/op/available-kits', ['uses' => 'Web\OPController@indexForStores', 'as' => 'op.storeIndex'] );


### PR DESCRIPTION
Expanding the OP section with totally new (community-created) content.

NEEDS:
- Someone to test it on a local instance (I don't have the dev environment set up)
- Setting up a redirect for nisei.net/find-people to nisei.net/op/around-the-world

Please bear with me, I haven't worked in code for quite a while and never with PHP, so... take all this with a pinch of salt ;-) Thanks!

