### PR TITLE
Attempting to add Twitter card support

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -6,6 +6,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <meta name="og:image" content="@yield('opengraph-image', url('/logo-large.png'))">
+    
+    <!-- Twitter cards -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@ProjectNISEI">
+    <meta name="twitter:title" content="@yield('page-title')">
+    <!-- twitter:description would go here if we had page summaries -->
+    <meta name="twitter:image" content="@yield('opengraph-image', url('/logo-large.png'))">
+    <!-- end Twitter cards -->
+
 
     <title>@yield('page-title')</title>
 


### PR DESCRIPTION
Following [this article](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image) to add Twitter card support. If we have page summaries and I don't know it, it should go in line 14 as `<meta name="twitter:description">`.